### PR TITLE
NEPT-1592: attributes array is optional in theme_link function.

### DIFF
--- a/template.php
+++ b/template.php
@@ -1184,9 +1184,14 @@ function ec_resp_link($variables) {
     }
   }
   $path = ($variables['path'] == '<nolink>') ? '#' : check_plain(url($variables['path'], $variables['options']));
+
+  $variables += array('options' => array());
+  $variables['options'] += array('attributes' => array());
+  $options_attributes = drupal_attributes($variables['options']['attributes']);
+
   $output = $action_bar_before . $btn_group_before .
     '<a href="' . $path . '"' .
-    drupal_attributes($variables['options']['attributes']) . '>' . $decoration .
+    $options_attributes . '>' . $decoration .
     ($variables['options']['html'] ? $variables['text'] : check_plain($variables['text'])) .
     '</a>' . $btn_group_after . $action_bar_after;
   return $output;


### PR DESCRIPTION
## NEPT-1592

### Description

NEPT-1592: attributes array is optional in theme_link function.

### Change log

- Fixed: cater for cases when attributes array is not set.

### Commands

```sh
[Insert commands here]
```